### PR TITLE
eslintとprittierの設定調整

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,8 @@ module.exports = {
 
     "plugin:jsx-a11y/recommended",
     "plugin:total-functions/recommended",
-    'prettier'
+    "prettier",
+    "plugin:prettier/recommended"
   ],
   ignorePatterns: ["dist"],
   parser: "@typescript-eslint/parser",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "format": "prettier --write ./src/*.tsx",
-    "lint": "eslint ./src/*.tsx --fix --quiet",
+    "format": "prettier --write \"**/*.{tsx}\"",
+    "lint": "eslint \"**/*.{tsx}\" --fix --quiet",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
１，Add plugin:prettier/recommended as the last item in the extends array in your .eslintrc* config file, so that eslint-config-prettier has the opportunity to override other configs:
https://www.npmjs.com/package/eslint-plugin-prettier
による、eslintrc.cjsの修正

２，package.jsonのscriptsの適切なpath設定に修正
